### PR TITLE
SVCWEB-118 Eslint: Only allow fixed versions in package.json

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3
-            - uses: volta-cli/action@v2.0.2
+            - uses: volta-cli/action@v4.0.0
             - name: Install
               run: npm ci
             - name: Build

--- a/.github/workflows/publish_to_npm.yml
+++ b/.github/workflows/publish_to_npm.yml
@@ -7,7 +7,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3
-            - uses: volta-cli/action@v2.0.2
+            - uses: volta-cli/action@v4.0.0
               with:
                   registry-url: 'https://registry.npmjs.org'
             - name: Install

--- a/packages/eslint-plugin-typescript/src/configs/recommended-package/rules/custom.ts
+++ b/packages/eslint-plugin-typescript/src/configs/recommended-package/rules/custom.ts
@@ -1,8 +1,11 @@
 import { Linter } from 'eslint';
 import { packageForcePrivate } from './custom/package-force-private';
+import { packageForceAbsoluteVersionDependenciesRule } from './custom/package-force-absolute-version-dependencies';
 
 const pluginPrefix = '@cloudflight/typescript';
 
 export const customRules: Linter.RulesRecord = {
     [`${pluginPrefix}/${packageForcePrivate.name}`]: packageForcePrivate.options,
+    [`${pluginPrefix}/${packageForceAbsoluteVersionDependenciesRule.name}`]:
+        packageForceAbsoluteVersionDependenciesRule.options,
 };

--- a/packages/eslint-plugin-typescript/src/configs/recommended-package/rules/custom/package-force-absolute-version-dependencies.md
+++ b/packages/eslint-plugin-typescript/src/configs/recommended-package/rules/custom/package-force-absolute-version-dependencies.md
@@ -1,0 +1,7 @@
+### @cloudflight/typescript/package-force-absolute-version-dependencies
+
+Using caret or tilde versions means you _blindly_ accept new versions of libraries, which can lead to different issues,
+such as:
+
+-   Your build can break, if the library author does not conform to semantic versioning standards.
+-   Malware can be introduced in new versions.

--- a/packages/eslint-plugin-typescript/src/configs/recommended-package/rules/custom/package-force-absolute-version-dependencies.ts
+++ b/packages/eslint-plugin-typescript/src/configs/recommended-package/rules/custom/package-force-absolute-version-dependencies.ts
@@ -1,0 +1,6 @@
+import type { RuleDefinition } from '../../../rule-definition';
+
+export const packageForceAbsoluteVersionDependenciesRule: RuleDefinition = {
+    name: 'package-force-absolute-version-dependencies',
+    options: ['error'],
+};

--- a/packages/eslint-plugin-typescript/src/rules/index.ts
+++ b/packages/eslint-plugin-typescript/src/rules/index.ts
@@ -18,9 +18,11 @@ import { TscNoUnusedLocalsRule } from './ts-config/tsc-no-unused-locals.rule';
 import { TscNoUnusedParametersRule } from './ts-config/tsc-no-unused-parameters.rule';
 import { TscUseDefineForClassFieldsRule } from './ts-config/tsc-use-define-for-class-fields.rule';
 import { NoMomentJsRule } from './no-moment-js';
+import { PackageForceAbsoluteVersionDependenciesRule } from './package/package-force-absolute-version-dependencies.rule';
 
 export const rules: Record<string, Rule.RuleModule> = {
     'package-force-private': PackageForcePrivateRule,
+    'package-force-absolute-version-dependencies': PackageForceAbsoluteVersionDependenciesRule,
     'tsc-allow-unreachable-code': TscAllowUnreachableCodeRule,
     'tsc-allow-unused-labels': TscAllowUnusedLabelsRule,
     'tsc-es-module-interop': TscEsModuleInteropRule,

--- a/packages/eslint-plugin-typescript/src/rules/package/package-force-absolute-version-dependencies.rule.spec.ts
+++ b/packages/eslint-plugin-typescript/src/rules/package/package-force-absolute-version-dependencies.rule.spec.ts
@@ -1,0 +1,106 @@
+import { RuleTester } from 'eslint';
+import { PackageForceAbsoluteVersionDependenciesRule } from './package-force-absolute-version-dependencies.rule';
+
+const ruleTester = new RuleTester({
+    parser: require.resolve('eslint-plugin-json-es'),
+});
+ruleTester.run('package-force-absolute-version-dependencies', PackageForceAbsoluteVersionDependenciesRule, {
+    valid: [
+        {
+            code: '{"dependencies": { "dependency": "1.0.0"}}',
+        },
+        {
+            code: '{"devDependencies": { "devDependency": "1.0.0"}}',
+        },
+        {
+            code: '{"dependencies": { "dependency": "1.0.0"}, "devDependencies": { "devDependency": "1.0.0"}}',
+        },
+        {
+            code: '{"dependencies": { "dependency": "http://asdf.com/asdf.tar.gz"}}',
+        },
+        {
+            code: '{"dependencies": { "dependency": "file:../dyl"}}',
+        },
+        {
+            code: '{"dependencies": { "dependency": "latest"}}',
+        },
+        {
+            code: '{"dependencies": { "dependency": "git+ssh://git@github.com:npm/cli.git"}}',
+        },
+        {
+            code: '{"dependencies": { "dependency": "user/repo#feature\\/branch"}}',
+        },
+    ],
+    invalid: [
+        {
+            code: '{"dependencies": { "dependency": ">1.0.0"}}',
+            output: '{"dependencies": { "dependency": "1.0.0"}}',
+            errors: [{ message: `dependencies option 'dependency' must be set to '1.0.0'!` }],
+        },
+        {
+            code: '{"devDependencies": { "dependency": ">1.0.0"}}',
+            output: '{"devDependencies": { "dependency": "1.0.0"}}',
+            errors: [{ message: `devDependencies option 'dependency' must be set to '1.0.0'!` }],
+        },
+        {
+            code: '{"dependencies": { "dependency": ">=1.0.0"}}',
+            output: '{"dependencies": { "dependency": "1.0.0"}}',
+            errors: [{ message: `dependencies option 'dependency' must be set to '1.0.0'!` }],
+        },
+        {
+            code: '{"dependencies": { "dependency": "<1.0.0"}}',
+            output: '{"dependencies": { "dependency": "1.0.0"}}',
+            errors: [{ message: `dependencies option 'dependency' must be set to '1.0.0'!` }],
+        },
+        {
+            code: '{"dependencies": { "dependency": "<=1.0.0"}}',
+            output: '{"dependencies": { "dependency": "1.0.0"}}',
+            errors: [{ message: `dependencies option 'dependency' must be set to '1.0.0'!` }],
+        },
+        {
+            code: '{"dependencies": { "dependency": "~1.0.0"}}',
+            output: '{"dependencies": { "dependency": "1.0.0"}}',
+            errors: [{ message: `dependencies option 'dependency' must be set to '1.0.0'!` }],
+        },
+        {
+            code: '{"dependencies": { "dependency": "^1.0.0"}}',
+            output: '{"dependencies": { "dependency": "1.0.0"}}',
+            errors: [{ message: `dependencies option 'dependency' must be set to '1.0.0'!` }],
+        },
+        {
+            code: '{"dependencies": { "dependency": "1.0.x"}}',
+            output: '{"dependencies": { "dependency": "1.0.0"}}',
+            errors: [{ message: `dependencies option 'dependency' must be set to '1.0.0'!` }],
+        },
+        {
+            code: '{"dependencies": { "dependency": "1.x.0"}}',
+            output: '{"dependencies": { "dependency": "1.0.0"}}',
+            errors: [{ message: `dependencies option 'dependency' must be set to '1.0.0'!` }],
+        },
+        {
+            code: '{"dependencies": { "dependency": "1.x.x"}}',
+            output: '{"dependencies": { "dependency": "1.0.0"}}',
+            errors: [{ message: `dependencies option 'dependency' must be set to '1.0.0'!` }],
+        },
+        {
+            code: '{"dependencies": { "dependency": "*"}}',
+            output: '{"dependencies": { "dependency": "*"}}',
+            errors: [{ message: `dependencies option 'dependency' must be set to an absolute version!` }],
+        },
+        {
+            code: '{"dependencies": { "dependency": ""}}',
+            output: '{"dependencies": { "dependency": ""}}',
+            errors: [{ message: `dependencies option 'dependency' must be set to an absolute version!` }],
+        },
+        {
+            code: '{"dependencies": { "dependency": "1.0.0 - 2.0.0"}}',
+            output: '{"dependencies": { "dependency": "1.0.0"}}',
+            errors: [{ message: `dependencies option 'dependency' must be set to '1.0.0'!` }],
+        },
+        {
+            code: '{"dependencies": { "dependency": "4.0.0 || 1.0.0 - 2.0.0"}}',
+            output: '{"dependencies": { "dependency": "4.0.0"}}',
+            errors: [{ message: `dependencies option 'dependency' must be set to '4.0.0'!` }],
+        },
+    ],
+});

--- a/packages/eslint-plugin-typescript/src/rules/package/package-force-absolute-version-dependencies.rule.ts
+++ b/packages/eslint-plugin-typescript/src/rules/package/package-force-absolute-version-dependencies.rule.ts
@@ -1,0 +1,53 @@
+import { Rule } from 'eslint';
+import { findPropertyPath, getPropertyName, reportWrongPropertyValue } from '../../util/json-util';
+
+const semVerRegex = /\d+\.(\d+|x)\.(\d+|x)/;
+
+export const PackageForceAbsoluteVersionDependenciesRule: Rule.RuleModule = {
+    create: (context) => {
+        return {
+            Property(propertyNode) {
+                const propertyPath = findPropertyPath(propertyNode);
+                const dependencyPath = propertyPath.match(/^\b(d|devD)ependencies\b/);
+
+                if (dependencyPath && propertyNode.value.type === 'Literal') {
+                    const propertyValue = JSON.stringify(propertyNode.value.value);
+                    const foundVersion = (propertyValue.match(semVerRegex) ?? [])[0];
+                    const isAnyVersion = propertyValue === JSON.stringify('*') || propertyValue === JSON.stringify('');
+
+                    if (foundVersion || isAnyVersion) {
+                        const dependencyContext = dependencyPath[0];
+                        const propertyName = getPropertyName(propertyNode);
+
+                        if (isAnyVersion && propertyName) {
+                            context.report({
+                                node: propertyNode,
+                                message: `${dependencyContext} option '${propertyName}' must be set to an absolute version!`,
+                            });
+                        } else if (foundVersion) {
+                            const isAbsoluteVersion =
+                                propertyValue.length === JSON.stringify(foundVersion).length &&
+                                !propertyValue.includes('x');
+
+                            if (!isAbsoluteVersion && dependencyContext && propertyName) {
+                                reportWrongPropertyValue(
+                                    context,
+                                    propertyNode,
+                                    {
+                                        key: propertyName,
+                                        expectedValue: foundVersion.replace(/x/g, '0'),
+                                    },
+                                    dependencyContext
+                                );
+                            }
+                        }
+                    }
+                }
+            },
+        };
+    },
+    meta: {
+        type: 'problem',
+        fixable: 'code',
+    },
+};


### PR DESCRIPTION
- Add new rule to enforce fixed versions in package.json dependencies and devDependencies
- Add tests verifying the intended behavior

Signed-off-by: Stefan Niederhumer <Stefan.Niederhumer@cloudflight.io>